### PR TITLE
Update api-server.js with correct ENV names

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -25,18 +25,18 @@ supertokens.init({
         ThirdPartyEmailPassword.init({
             providers: [
                 ThirdPartyEmailPassword.Google({
-                    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-                    clientId: process.env.GOOGLE_CLIENT_ID
+                    clientSecret: process.env.REACT_APP_GOOGLE_CLIENT_SECRET,
+                    clientId: process.env.REACT_APP_GOOGLE_CLIENT_ID
                 }),
                 ThirdPartyEmailPassword.Github({
-                    clientSecret: process.env.GITHUB_CLIENT_SECRET,
-                    clientId: process.env.GITHUB_CLIENT_ID
+                    clientSecret: process.env.REACT_APP_GITHUB_CLIENT_SECRET,
+                    clientId: process.env.REACT_APP_GITHUB_CLIENT_ID
                 }),
 
                 // we have commented the below because our app domain (ThirdPartyEmailPassword.demo.supertokens.io) is not approved by Facebook since it's only a demo app.
                 // ThirdPartyEmailPassword.Facebook({
-                //     clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
-                //     clientId: process.env.FACEBOOK_CLIENT_ID
+                //     clientSecret: process.env.REACT_APP_FACEBOOK_CLIENT_SECRET,
+                //     clientId: process.env.REACT_APP_FACEBOOK_CLIENT_ID
                 // })
             ]
         }),


### PR DESCRIPTION
fix ENV variable names so they match what's in `.env.example`, otherwise the app crashes on startup due to `missing clientId`. Not a good first experience ;)